### PR TITLE
Fix incorrect `github_url` values in documentation

### DIFF
--- a/docs/gcms_metabolomics/index.html
+++ b/docs/gcms_metabolomics/index.html
@@ -2,7 +2,7 @@
 <dt>github_url</dt>
 <dd>
 <p><a
-href="https://github.com/microbiomedata/metaMS/blob/master/docs/index.rst">https://github.com/microbiomedata/metaMS/blob/master/docs/index.rst</a></p>
+href="https://github.com/microbiomedata/metaMS/blob/master/docs/gcms_metabolomics/index.rst">https://github.com/microbiomedata/metaMS/blob/master/docs/gcms_metabolomics/index.rst</a></p>
 </dd>
 </dl>
 <h1 id="metabolomics-workflow">Metabolomics Workflow</h1>

--- a/docs/gcms_metabolomics/index.rst
+++ b/docs/gcms_metabolomics/index.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/microbiomedata/metaMS/blob/master/docs/index.rst
+:github_url: https://github.com/microbiomedata/metaMS/blob/master/docs/gcms_metabolomics/index.rst
 
 ..
    Note: The above `github_url` field is used to force the target of the "Edit on GitHub" link

--- a/docs/lcms_lipidomics/index.html
+++ b/docs/lcms_lipidomics/index.html
@@ -2,7 +2,7 @@
 <dt>github_url</dt>
 <dd>
 <p><a
-href="https://github.com/microbiomedata/metaMS/blob/master/docs/index_lipid.rst">https://github.com/microbiomedata/metaMS/blob/master/docs/index_lipid.rst</a></p>
+href="https://github.com/microbiomedata/metaMS/blob/master/docs/lcms_lipidomics/index.rst">https://github.com/microbiomedata/metaMS/blob/master/docs/lcms_lipidomics/index.rst</a></p>
 </dd>
 </dl>
 <h1 id="lipidomics-workflow-v1.4.0">Lipidomics Workflow (v1.4.0)</h1>

--- a/docs/lcms_lipidomics/index.rst
+++ b/docs/lcms_lipidomics/index.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/microbiomedata/metaMS/blob/master/docs/index_lipid.rst
+:github_url: https://github.com/microbiomedata/metaMS/blob/master/docs/lcms_lipidomics/index.rst
 
 ..
    Note: The above `github_url` field is used to force the target of the "Edit on GitHub" link

--- a/docs/lcms_metabolomics/index.html
+++ b/docs/lcms_metabolomics/index.html
@@ -2,7 +2,7 @@
 <dt>github_url</dt>
 <dd>
 <p><a
-href="https://github.com/microbiomedata/metaMS/blob/master/docs/index_lipid.rst">https://github.com/microbiomedata/metaMS/blob/master/docs/index_lipid.rst</a></p>
+href="https://github.com/microbiomedata/metaMS/blob/master/docs/lcms_metabolomics/index.rst">https://github.com/microbiomedata/metaMS/blob/master/docs/lcms_metabolomics/index.rst</a></p>
 </dd>
 </dl>
 <p>LC/MS Metabolomics Workflow (v1.2.0) ============================</p>

--- a/docs/lcms_metabolomics/index.rst
+++ b/docs/lcms_metabolomics/index.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/microbiomedata/metaMS/blob/master/docs/index_lipid.rst
+:github_url: https://github.com/microbiomedata/metaMS/blob/master/docs/lcms_metabolomics/index.rst
 
 ..
    Note: The above `github_url` field is used to force the target of the "Edit on GitHub" link


### PR DESCRIPTION
On this branch, I updated the `github_url` values (URLs) in three pairs of files:
- the RST and HTML files in `docs/gcms_metabolomics/`
- the RST and HTML files in `docs/lcms_lipidomics/`
- the RST and HTML files in `docs/lcms_metabolomics/`

I updated the URLs to be the GitHub URLs to the RST files.

Fixes https://github.com/microbiomedata/metaMS/issues/79 (affecting the `docs` website; i.e. https://docs.microbiomedata.org). Note: The `docs` site only uses the RST files. I opted to update the HTML files, too, because I assumed y'all would want them to match.